### PR TITLE
Adds pre-defined type names support to plugins

### DIFF
--- a/Sources/class-generator/ClassGenerator.swift
+++ b/Sources/class-generator/ClassGenerator.swift
@@ -245,6 +245,10 @@ internal class ClassGenerator {
 
 extension ClassGenerator {
 
+    private func classGenLog(_ message: String) {
+        Log.info(message)
+    }
+
     private func configureJavaScriptContext() throws {
         // configure an exception handler
         javaScriptContext.exceptionHandler = { context, exception in
@@ -253,6 +257,15 @@ extension ClassGenerator {
                 exit(1)
             }
         }
+
+        // expose the classGenLog method to JavaScript
+        let javaScriptLogHandler: @convention(block) (String) -> Void = { [weak self] message in
+            self?.classGenLog(message)
+        }
+        let javaScriptLogHandlerObject = unsafeBitCast(javaScriptLogHandler, to: AnyObject.self)
+        javaScriptContext.setObject(javaScriptLogHandlerObject,
+                                    forKeyedSubscript: "classGenLog" as (NSCopying & NSObjectProtocol)!)
+        _ = javaScriptContext.evaluateScript("classGenLog")
 
         // expose the registerPreDefinedTypes method to JavaScript
         let registerPreDefinedTypesHandler: @convention(block) ([String]) -> Void

--- a/Sources/class-generator/ClassGenerator.swift
+++ b/Sources/class-generator/ClassGenerator.swift
@@ -12,9 +12,9 @@ internal enum ClassGeneratorError: Error {
     case outputDirectoryIsNotADirectory(String)
     case outputDirectoryIsNotEmpty(String)
     case outputDirectoryWasNotSpecified
-    case pluginDirectoryDoesNotExist(String)
-    case pluginDirectoryIsEmpty(String)
-    case pluginDirectoryIsNotADirectory(String)
+    case pluginsDirectoryDoesNotExist(String)
+    case pluginsDirectoryIsEmpty(String)
+    case pluginsDirectoryIsNotADirectory(String)
     case schemasDirectoryDoesNotExist(String)
     case schemasDirectoryIsEmpty(String)
     case schemasDirectoryIsNotADirectory(String)
@@ -29,7 +29,7 @@ internal class ClassGenerator {
 
     var alphabetizeProperties: Bool
     var outputDirectoryPath: Path?
-    var pluginDirectoryPath: Path?
+    var pluginsDirectoryPath: Path?
 
     // MARK: - Private Properties
 
@@ -45,7 +45,7 @@ internal class ClassGenerator {
         self.alphabetizeProperties = false
         self.javaScriptContext = JSContext()
         self.outputDirectoryPath = nil
-        self.pluginDirectoryPath = nil
+        self.pluginsDirectoryPath = nil
         self.preDefinedTypes = []
         self.schemasDirectoryPath = schemasDirectoryPath
         self.templateExtension = Extension()
@@ -198,7 +198,7 @@ internal class ClassGenerator {
         try validateSchemasDirectoryPath()
         try validateTemplateFilePath()
         try validateOutputDirectoryPath()
-        try validatePluginDirectoryPath()
+        try validatePluginsDirectoryPath()
     }
 
     private func validateSchemasDirectoryPath() throws {
@@ -306,11 +306,11 @@ extension ClassGenerator {
     }
 
     private func loadPlugins() throws {
-        guard let pluginDirectoryPath = pluginDirectoryPath else {
+        guard let pluginsDirectoryPath = pluginsDirectoryPath else {
             return
         }
 
-        try pluginDirectoryPath.children().forEach { pluginFilePath in
+        try pluginsDirectoryPath.children().forEach { pluginFilePath in
             guard pluginFilePath.isFile, pluginFilePath.extension == "js" else {
                 Log.warning("Skipping unknown plugin file type: \(pluginFilePath.lastComponent)")
                 return
@@ -364,29 +364,29 @@ extension ClassGenerator {
         preDefinedTypes = Set<String>(typeNames)
     }
 
-    private func validatePluginDirectoryPath() throws {
-        guard let pluginDirectoryPath = pluginDirectoryPath else {
+    private func validatePluginsDirectoryPath() throws {
+        guard let pluginsDirectoryPath = pluginsDirectoryPath else {
             return
         }
 
-        let absolutePath = pluginDirectoryPath.absolute().string
+        let absolutePath = pluginsDirectoryPath.absolute().string
 
-        // ensure the plugin directory exists
-        guard pluginDirectoryPath.exists else {
+        // ensure the plugins directory exists
+        guard pluginsDirectoryPath.exists else {
             Log.error("The plugin directory specified does not exist: " + absolutePath)
-            throw ClassGeneratorError.pluginDirectoryDoesNotExist(absolutePath)
+            throw ClassGeneratorError.pluginsDirectoryDoesNotExist(absolutePath)
         }
 
-        // ensure the plugin directory is a directory
-        guard pluginDirectoryPath.isDirectory else {
+        // ensure the plugins directory is a directory
+        guard pluginsDirectoryPath.isDirectory else {
             Log.error("The plugin directory specified is not a directory: " + absolutePath)
-            throw ClassGeneratorError.pluginDirectoryIsNotADirectory(absolutePath)
+            throw ClassGeneratorError.pluginsDirectoryIsNotADirectory(absolutePath)
         }
 
-        // ensure the plugin directory is not empty
-        guard try !pluginDirectoryPath.children().isEmpty else {
+        // ensure the plugins directory is not empty
+        guard try !pluginsDirectoryPath.children().isEmpty else {
             Log.error("The plugin directory specified is empty: " + absolutePath)
-            throw ClassGeneratorError.pluginDirectoryIsEmpty(absolutePath)
+            throw ClassGeneratorError.pluginsDirectoryIsEmpty(absolutePath)
         }
     }
 

--- a/Sources/class-generator/GenerateCommand.swift
+++ b/Sources/class-generator/GenerateCommand.swift
@@ -14,7 +14,7 @@ internal class GenerateCommand: SwiftCLI.Command {
     // options
     private let alphabetizeProperties = Flag("--alphabetize-properties", description: "The generated properties will be listed alphabetical order.")
     private let outputDirectoryPath = Key<String>("--output-directory-path", description: "The output directory where all generated files will be saved to.  A temporary directory will be used if none is provided.")
-    private let pluginDirectoryPath = Key<String>("--plugin-directory-path", description: "A directory containing plugins which will be loaded at runtime.")
+    private let pluginsDirectoryPath = Key<String>("--plugins-directory-path", description: "A directory containing plugins which will be loaded at runtime.")
 
     // MARK: - Command Protocol
 
@@ -31,8 +31,8 @@ internal class GenerateCommand: SwiftCLI.Command {
             generator.outputDirectoryPath = Path(outputDirectoryPath)
         }
 
-        if let pluginDirectoryPath = pluginDirectoryPath.value {
-            generator.pluginDirectoryPath = Path(pluginDirectoryPath)
+        if let pluginsDirectoryPath = pluginsDirectoryPath.value {
+            generator.pluginsDirectoryPath = Path(pluginsDirectoryPath)
         }
 
         try generator.generate()

--- a/Sources/class-generator/Model/Class.swift
+++ b/Sources/class-generator/Model/Class.swift
@@ -10,7 +10,7 @@ internal class Class: ImmutableMappable {
 
     // MARK: - Private Enums
 
-    fileprivate enum Keys: String {
+    private enum Keys: String {
         case name
         case properties
     }

--- a/Sources/class-generator/Model/Property.swift
+++ b/Sources/class-generator/Model/Property.swift
@@ -48,7 +48,7 @@ internal class Property: ImmutableMappable {
 
     // MARK: - Private Enums
 
-    fileprivate enum Keys: String {
+    private enum Keys: String {
         case name
         case type
         case description

--- a/Sources/class-generator/main.swift
+++ b/Sources/class-generator/main.swift
@@ -2,10 +2,17 @@ import HeliumLogger
 import LoggerAPI
 import SwiftCLI
 
-// setup logging
+// build the log format: "[date] [type] message"
+let logFormat = "[%@] [%@] %@"
+let logFormatValues: [HeliumLoggerFormatValues] = [.date, .logType, .message]
+let logFormatArgs = logFormatValues.map { $0.rawValue }
+
+// create the logger
 let logger = HeliumLogger(.info)
 logger.colored = true
-logger.format = "[(%date)] [(%type)] (%msg)"
+logger.format = String(format: logFormat, arguments: logFormatArgs)
+
+// set the logger
 Log.logger = logger
 
 // setup the command line interface


### PR DESCRIPTION
Adds the ability to register pre-defined type names via a plugin.

### Example
In a plugin file (a JavaScript file located in the specified `--plugins-directory-path` directory), simply register the desired pre-defined type names as follows:

```JavaScript
registerPreDefinedTypes(["Bool", "Date", "Decimal", "Double", "Float", "Int", "Long", "String"])
```